### PR TITLE
Add Ollama-driven news coverage comparison toolkit (news_compare/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,33 @@ Replace the placeholder content in `content/` and update sections in `app/page.t
 
 ## Deployment
 The project is configured for static export (`next build && next export`), making it ready for deployment on [Vercel](https://vercel.com) or any static hosting service.
+
+## News Coverage Comparator (Python)
+A standalone Python toolkit was added under `news_compare/` to compare two agencies' coverage of a topic using your Ollama server.
+
+### Features
+- LLM-based discovery of each agency's official homepage/feed endpoints.
+- Adaptive scraping for up to 100 recent articles per agency with fallback levels:
+  1. full text
+  2. abstract (title + opening lines/meta description)
+  3. title only
+- LLM classification per article (sentiment + narrative stance + themes).
+- Comparison outputs: overlap, topic/theme trends, sentiment/stance distributions.
+- Interactive D3.js dashboard (timeline + dual word clouds).
+
+### Run
+```bash
+python -m news_compare.main "Reuters" "Al Jazeera" "Iran" \
+  --ollama-url http://localhost:11434 \
+  --discovery-model llama3.1 \
+  --analysis-model llama3.1 \
+  --max-articles 100
+```
+
+### Outputs
+Generated in `news_compare/output/`:
+- `discovered_endpoints.json`
+- `articles.json`
+- `analyses.json`
+- `comparison_stats.json`
+- `comparison_dashboard.html`

--- a/news_compare/__init__.py
+++ b/news_compare/__init__.py
@@ -1,0 +1,1 @@
+"""News coverage comparison toolkit."""

--- a/news_compare/analysis.py
+++ b/news_compare/analysis.py
@@ -1,0 +1,105 @@
+"""LLM-based stance/sentiment analysis and comparison metrics."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, asdict
+from itertools import chain
+from typing import Dict, List
+
+import requests
+
+from .scraper import Article
+
+
+@dataclass
+class ArticleAnalysis:
+    agency: str
+    url: str
+    title: str
+    sentiment: str
+    stance: str
+    themes: List[str]
+    confidence: float
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class OllamaAnalyzer:
+    def __init__(self, base_url: str, model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    def analyze_articles(self, topic: str, articles: List[Article]) -> List[ArticleAnalysis]:
+        results: List[ArticleAnalysis] = []
+        for article in articles:
+            prompt = (
+                "Classify the article's sentiment and narrative stance regarding the target topic.\n"
+                "Return strict JSON with keys: sentiment (positive/negative/neutral/mixed), "
+                "stance (supportive/critical/balanced/unclear), themes (array of short strings), confidence (0-1).\n"
+                f"Target topic: {topic}\n"
+                f"Title: {article.title}\n"
+                f"Content:\n{article.content[:5000]}"
+            )
+            payload = {
+                "model": self.model,
+                "prompt": prompt,
+                "stream": False,
+                "format": "json",
+            }
+            try:
+                resp = requests.post(
+                    f"{self.base_url}/api/generate", json=payload, timeout=90
+                )
+                resp.raise_for_status()
+                parsed = json.loads(resp.json().get("response", "{}"))
+            except Exception:
+                parsed = {}
+
+            results.append(
+                ArticleAnalysis(
+                    agency=article.agency,
+                    url=article.url,
+                    title=article.title,
+                    sentiment=parsed.get("sentiment", "unknown"),
+                    stance=parsed.get("stance", "unclear"),
+                    themes=parsed.get("themes", []),
+                    confidence=float(parsed.get("confidence", 0.0) or 0.0),
+                )
+            )
+        return results
+
+
+def compare_coverage(agency_a: str, agency_b: str, analyses: List[ArticleAnalysis]) -> Dict:
+    a = [x for x in analyses if x.agency == agency_a]
+    b = [x for x in analyses if x.agency == agency_b]
+
+    themes_a = Counter(chain.from_iterable(x.themes for x in a))
+    themes_b = Counter(chain.from_iterable(x.themes for x in b))
+    overlap = sorted(set(themes_a) & set(themes_b))
+
+    def counts(items: List[ArticleAnalysis], field: str) -> Dict[str, int]:
+        c = Counter(getattr(x, field) for x in items)
+        return dict(c)
+
+    return {
+        "agency_counts": {agency_a: len(a), agency_b: len(b)},
+        "overlap_themes": overlap,
+        "overlap_rate": (
+            len(overlap) / max(1, len(set(themes_a) | set(themes_b)))
+        ),
+        "top_themes": {
+            agency_a: themes_a.most_common(20),
+            agency_b: themes_b.most_common(20),
+        },
+        "sentiment_distribution": {
+            agency_a: counts(a, "sentiment"),
+            agency_b: counts(b, "sentiment"),
+        },
+        "stance_distribution": {
+            agency_a: counts(a, "stance"),
+            agency_b: counts(b, "stance"),
+        },
+    }

--- a/news_compare/config.py
+++ b/news_compare/config.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class AppConfig:
+    ollama_base_url: str = "http://localhost:11434"
+    discovery_model: str = "llama3.1"
+    analysis_model: str = "llama3.1"
+    max_articles_per_agency: int = 100
+    output_dir: Path = Path("news_compare/output")
+
+
+DEFAULT_CONFIG = AppConfig()

--- a/news_compare/llm_discovery.py
+++ b/news_compare/llm_discovery.py
@@ -1,0 +1,49 @@
+"""LLM-assisted website/API discovery for news agencies."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import List
+
+import requests
+
+
+@dataclass
+class AgencyEndpoint:
+    name: str
+    homepage_url: str
+    api_or_feed_urls: List[str]
+
+
+class OllamaDiscoveryClient:
+    def __init__(self, base_url: str, model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    def discover(self, agency_name: str) -> AgencyEndpoint:
+        prompt = (
+            "Given only the agency name, identify the official news homepage URL and "
+            "up to 5 likely API/feed/article-index endpoints (RSS, sitemap, JSON API).\n"
+            "Return strict JSON with keys: name, homepage_url, api_or_feed_urls (array of strings).\n"
+            f"Agency: {agency_name}"
+        )
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "format": "json",
+        }
+
+        response = requests.post(
+            f"{self.base_url}/api/generate", json=payload, timeout=60
+        )
+        response.raise_for_status()
+        raw = response.json().get("response", "{}")
+        data = json.loads(raw)
+
+        return AgencyEndpoint(
+            name=data.get("name", agency_name),
+            homepage_url=data.get("homepage_url", "").strip(),
+            api_or_feed_urls=[u.strip() for u in data.get("api_or_feed_urls", []) if u],
+        )

--- a/news_compare/main.py
+++ b/news_compare/main.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .analysis import compare_coverage, OllamaAnalyzer
+from .config import DEFAULT_CONFIG
+from .llm_discovery import OllamaDiscoveryClient
+from .scraper import AdaptiveScraper
+from .visualization import build_visual_payload, write_visualization_html
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare two agencies' topic coverage.")
+    parser.add_argument("agency_a", help="First agency name (e.g., Reuters)")
+    parser.add_argument("agency_b", help="Second agency name (e.g., Al Jazeera)")
+    parser.add_argument("topic", help="Topic to compare (e.g., Iran)")
+    parser.add_argument("--ollama-url", default=DEFAULT_CONFIG.ollama_base_url)
+    parser.add_argument("--discovery-model", default=DEFAULT_CONFIG.discovery_model)
+    parser.add_argument("--analysis-model", default=DEFAULT_CONFIG.analysis_model)
+    parser.add_argument("--max-articles", type=int, default=DEFAULT_CONFIG.max_articles_per_agency)
+    parser.add_argument("--output-dir", default=str(DEFAULT_CONFIG.output_dir))
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    discover = OllamaDiscoveryClient(args.ollama_url, args.discovery_model)
+    scraper = AdaptiveScraper(args.max_articles)
+    analyzer = OllamaAnalyzer(args.ollama_url, args.analysis_model)
+
+    endpoint_a = discover.discover(args.agency_a)
+    endpoint_b = discover.discover(args.agency_b)
+
+    articles_a = scraper.scrape(
+        endpoint_a.name, endpoint_a.homepage_url, endpoint_a.api_or_feed_urls
+    )
+    articles_b = scraper.scrape(
+        endpoint_b.name, endpoint_b.homepage_url, endpoint_b.api_or_feed_urls
+    )
+    all_articles = articles_a + articles_b
+
+    analyses = analyzer.analyze_articles(args.topic, all_articles)
+    comparison = compare_coverage(endpoint_a.name, endpoint_b.name, analyses)
+    visual_payload = build_visual_payload(all_articles, analyses)
+
+    (output_dir / "discovered_endpoints.json").write_text(
+        json.dumps(
+            {
+                endpoint_a.name: {
+                    "homepage": endpoint_a.homepage_url,
+                    "feeds": endpoint_a.api_or_feed_urls,
+                },
+                endpoint_b.name: {
+                    "homepage": endpoint_b.homepage_url,
+                    "feeds": endpoint_b.api_or_feed_urls,
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (output_dir / "articles.json").write_text(
+        json.dumps([a.to_dict() for a in all_articles], indent=2), encoding="utf-8"
+    )
+    (output_dir / "analyses.json").write_text(
+        json.dumps([a.to_dict() for a in analyses], indent=2), encoding="utf-8"
+    )
+    (output_dir / "comparison_stats.json").write_text(
+        json.dumps(comparison, indent=2), encoding="utf-8"
+    )
+    write_visualization_html(args.topic, visual_payload, output_dir / "comparison_dashboard.html")
+
+    print(f"Saved outputs in {output_dir.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/news_compare/requirements.txt
+++ b/news_compare/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/news_compare/scraper.py
+++ b/news_compare/scraper.py
@@ -1,0 +1,174 @@
+"""Adaptive article discovery and content extraction."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from typing import List, Optional
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+
+@dataclass
+class Article:
+    agency: str
+    url: str
+    title: str
+    published_at: Optional[str]
+    text_mode: str  # full_text | abstract | title_only
+    content: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class AdaptiveScraper:
+    USER_AGENT = "Mozilla/5.0 (NewsComparatorBot/1.0)"
+
+    def __init__(self, max_articles: int = 100) -> None:
+        self.max_articles = max_articles
+
+    def scrape(self, agency_name: str, homepage_url: str, candidate_urls: List[str]) -> List[Article]:
+        urls = [u for u in candidate_urls if u]
+        if homepage_url:
+            urls.append(homepage_url)
+
+        article_urls: List[str] = []
+        for source in urls:
+            article_urls.extend(self._discover_article_links(source, homepage_url))
+            if len(article_urls) >= self.max_articles:
+                break
+
+        deduped = list(dict.fromkeys(article_urls))[: self.max_articles]
+        articles: List[Article] = []
+        for url in deduped:
+            article = self._extract_article(agency_name, url)
+            if article:
+                articles.append(article)
+        return articles
+
+    def _request(self, url: str) -> Optional[requests.Response]:
+        try:
+            resp = requests.get(url, headers={"User-Agent": self.USER_AGENT}, timeout=25)
+            if resp.ok:
+                return resp
+        except requests.RequestException:
+            return None
+        return None
+
+    def _discover_article_links(self, source_url: str, homepage_url: str) -> List[str]:
+        resp = self._request(source_url)
+        if not resp:
+            return []
+
+        content_type = resp.headers.get("content-type", "")
+        text = resp.text
+        links: List[str] = []
+
+        if "xml" in content_type or source_url.endswith((".xml", "/rss", "rss")):
+            links.extend(self._parse_rss_links(text))
+        else:
+            soup = BeautifulSoup(text, "html.parser")
+            for a in soup.select("a[href]"):
+                href = a.get("href", "").strip()
+                if href.startswith("#") or href.startswith("javascript:"):
+                    continue
+                full = urljoin(source_url or homepage_url, href)
+                if self._looks_like_article_url(full):
+                    links.append(full)
+
+        return links
+
+    def _parse_rss_links(self, xml_text: str) -> List[str]:
+        links: List[str] = []
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError:
+            return links
+        for item in root.findall(".//item") + root.findall(".//entry"):
+            link_elem = item.find("link")
+            if link_elem is not None:
+                href = link_elem.get("href") or (link_elem.text or "")
+                if href:
+                    links.append(href.strip())
+        return links
+
+    def _extract_article(self, agency: str, url: str) -> Optional[Article]:
+        resp = self._request(url)
+        if not resp:
+            return None
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        title = self._extract_title(soup) or url
+        published_at = self._extract_published_date(soup, resp.headers.get("date", ""))
+
+        full_text = self._extract_full_text(soup)
+        if full_text:
+            return Article(agency, url, title, published_at, "full_text", full_text)
+
+        abstract = self._extract_abstract(soup, title)
+        if abstract:
+            return Article(agency, url, title, published_at, "abstract", abstract)
+
+        return Article(agency, url, title, published_at, "title_only", title)
+
+    def _extract_title(self, soup: BeautifulSoup) -> str:
+        if soup.title and soup.title.string:
+            return soup.title.string.strip()
+        h1 = soup.find("h1")
+        return h1.get_text(" ", strip=True) if h1 else ""
+
+    def _extract_published_date(self, soup: BeautifulSoup, header_date: str) -> Optional[str]:
+        for attr in [
+            ("meta", {"property": "article:published_time"}, "content"),
+            ("meta", {"name": "pubdate"}, "content"),
+            ("time", {}, "datetime"),
+        ]:
+            tag = soup.find(attr[0], attrs=attr[1])
+            if tag and tag.get(attr[2]):
+                return tag.get(attr[2])
+        if header_date:
+            try:
+                return parsedate_to_datetime(header_date).isoformat()
+            except Exception:
+                return None
+        return None
+
+    def _extract_full_text(self, soup: BeautifulSoup) -> str:
+        article = soup.find("article")
+        if article:
+            text = article.get_text("\n", strip=True)
+            if len(text.split()) > 120:
+                return text
+
+        paragraphs = [p.get_text(" ", strip=True) for p in soup.find_all("p")]
+        combined = "\n".join([p for p in paragraphs if len(p.split()) > 6])
+        return combined if len(combined.split()) > 180 else ""
+
+    def _extract_abstract(self, soup: BeautifulSoup, title: str) -> str:
+        meta = soup.find("meta", attrs={"name": "description"}) or soup.find(
+            "meta", attrs={"property": "og:description"}
+        )
+        desc = meta.get("content", "").strip() if meta else ""
+
+        lines = []
+        for p in soup.find_all("p")[:3]:
+            txt = p.get_text(" ", strip=True)
+            if txt:
+                lines.append(txt)
+
+        joined = "\n".join(lines)
+        abstract = "\n".join([title, desc, joined]).strip()
+        return abstract if len(abstract) > len(title) else ""
+
+    def _looks_like_article_url(self, url: str) -> bool:
+        lowered = url.lower()
+        if any(x in lowered for x in ["/video", "/live", "/tag/", "/topic/"]):
+            return False
+        pattern = r"\d{4}/\d{2}/\d{2}|/news/|/article|/story"
+        return bool(re.search(pattern, lowered))

--- a/news_compare/visualization.py
+++ b/news_compare/visualization.py
@@ -1,0 +1,124 @@
+"""Generate D3.js visualizations (timeline + thematic word cloud)."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from .analysis import ArticleAnalysis
+from .scraper import Article
+
+
+HTML_TEMPLATE = """<!doctype html>
+<html>
+<head>
+  <meta charset=\"utf-8\" />
+  <title>News Coverage Comparison</title>
+  <script src=\"https://d3js.org/d3.v7.min.js\"></script>
+  <script src=\"https://cdn.jsdelivr.net/npm/d3-cloud@1/build/d3.layout.cloud.js\"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    .row { display: flex; gap: 24px; }
+    .chart { border: 1px solid #ddd; padding: 8px; border-radius: 8px; }
+    .tooltip { position: absolute; pointer-events: none; background: #fff; border:1px solid #333; padding:6px; }
+  </style>
+</head>
+<body>
+<h1>Coverage Comparison: __TOPIC__</h1>
+<div id=\"timeline\" class=\"chart\"></div>
+<div class=\"row\">
+  <div id=\"wordcloudA\" class=\"chart\"></div>
+  <div id=\"wordcloudB\" class=\"chart\"></div>
+</div>
+<script>
+const payload = __DATA__;
+
+const timelineDiv = d3.select('#timeline');
+const width = 1000, height = 280;
+const svg = timelineDiv.append('svg').attr('width', width).attr('height', height);
+const points = payload.timeline.filter(d => d.date);
+const parseDate = d3.utcParse('%Y-%m-%d');
+points.forEach(d => d.dt = parseDate(d.date));
+
+const x = d3.scaleTime().domain(d3.extent(points, d => d.dt)).range([50, width - 20]);
+const y = d3.scalePoint().domain(payload.agencies).range([50, height - 30]);
+svg.append('g').attr('transform', `translate(0,${height-30})`).call(d3.axisBottom(x));
+svg.append('g').attr('transform', 'translate(50,0)').call(d3.axisLeft(y));
+svg.selectAll('circle').data(points).enter().append('circle')
+  .attr('cx', d => x(d.dt)).attr('cy', d => y(d.agency)).attr('r', 4)
+  .attr('fill', d => d.stance === 'critical' ? '#d62728' : d.stance === 'supportive' ? '#2ca02c' : '#1f77b4')
+  .append('title').text(d => `${d.title} (${d.sentiment}/${d.stance})`);
+
+function drawCloud(nodeId, words, title) {
+  d3.select(nodeId).append('h3').text(title);
+  const w = 480, h = 360;
+  const svg = d3.select(nodeId).append('svg').attr('width', w).attr('height', h)
+      .append('g').attr('transform', `translate(${w/2},${h/2})`);
+  d3.layout.cloud().size([w, h]).words(words.map(d => ({text: d.word, size: 12 + d.count*2})))
+    .padding(3).rotate(() => (Math.random() > 0.8 ? 90 : 0))
+    .font('sans-serif').fontSize(d => d.size)
+    .on('end', draw).start();
+  function draw(words) {
+    svg.selectAll('text').data(words).enter().append('text')
+      .style('font-size', d => d.size + 'px').style('fill', '#333')
+      .attr('text-anchor', 'middle').attr('transform', d => `translate(${d.x},${d.y})rotate(${d.rotate})`)
+      .text(d => d.text);
+  }
+}
+
+drawCloud('#wordcloudA', payload.wordcloud[payload.agencies[0]], payload.agencies[0] + ' themes');
+drawCloud('#wordcloudB', payload.wordcloud[payload.agencies[1]], payload.agencies[1] + ' themes');
+</script>
+</body>
+</html>
+"""
+
+
+def _short_date(iso: str | None) -> str | None:
+    if not iso:
+        return None
+    try:
+        return datetime.fromisoformat(iso.replace("Z", "+00:00")).date().isoformat()
+    except Exception:
+        return None
+
+
+def build_visual_payload(articles: List[Article], analyses: List[ArticleAnalysis]) -> Dict:
+    analysis_by_url = {a.url: a for a in analyses}
+    timeline = []
+    themes_by_agency: Dict[str, Counter] = {}
+    agencies = sorted(set(a.agency for a in articles))
+
+    for article in articles:
+        a = analysis_by_url.get(article.url)
+        if not a:
+            continue
+        timeline.append(
+            {
+                "agency": article.agency,
+                "date": _short_date(article.published_at),
+                "title": article.title,
+                "sentiment": a.sentiment,
+                "stance": a.stance,
+            }
+        )
+        themes_by_agency.setdefault(article.agency, Counter()).update(a.themes)
+
+    wordcloud = {
+        agency: [{"word": w, "count": c} for w, c in counter.most_common(50)]
+        for agency, counter in themes_by_agency.items()
+    }
+    for agency in agencies:
+        wordcloud.setdefault(agency, [])
+
+    return {"timeline": timeline, "wordcloud": wordcloud, "agencies": agencies}
+
+
+def write_visualization_html(topic: str, payload: Dict, output_file: Path) -> None:
+    html = HTML_TEMPLATE.replace("__TOPIC__", topic).replace(
+        "__DATA__", json.dumps(payload)
+    )
+    output_file.write_text(html, encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Provide a standalone Python toolkit to compare how two news agencies cover a topic by leveraging an on-prem Ollama LLM for endpoint discovery and content analysis.
- Enable adaptive scraping with sensible fallbacks so the tool can extract usable content from diverse news sites (full text → abstract → title-only).
- Produce structured outputs and an interactive D3.js dashboard to make cross-agency theme/timeline/stance comparisons easily shareable.

### Description
- Add a new package `news_compare/` containing multi-module implementation: `llm_discovery.py` (Ollama-assisted homepage/feed discovery), `scraper.py` (adaptive article discovery and extraction), `analysis.py` (LLM-based sentiment/stance/themes + `compare_coverage` metrics), `visualization.py` (HTML + D3 timeline and dual word clouds), `config.py` (defaults), and `main.py` (CLI orchestrator and output writer).
- Integrate with an Ollama server via `requests` to generate structured discovery and analysis prompts, with JSON parsing and safe fallbacks when the LLM response fails.
- Write results to disk under `news_compare/output/` including `discovered_endpoints.json`, `articles.json`, `analyses.json`, `comparison_stats.json`, and `comparison_dashboard.html` and document running instructions in `README.md` with an example `python -m news_compare.main` command.
- Add a minimal `news_compare/requirements.txt` listing `requests` and `beautifulsoup4` and include configurable defaults for Ollama URL, models, max articles, and output directory in `config.py`.

### Testing
- Ran `python -m compileall news_compare` to byte-compile the new package, which completed successfully.
- Attempted to run `python -m news_compare.main --help` in this environment which failed due to a missing runtime dependency `requests`; the dependency is declared in `news_compare/requirements.txt` so installing requirements resolves the failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a842c2c7c8832f836d0defeaf02a2e)